### PR TITLE
Increase site header navigation height from 64px to 208px

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,7 @@ img{max-width:100%;display:block}
 .container{max-width:1120px;margin:0 auto;padding:0 20px}
 
 .site-header{position:sticky;top:0;background:rgba(255,255,255,.9);backdrop-filter:saturate(140%) blur(6px);border-bottom:1px solid #eef2f7;z-index:1000}
-.site-header .nav{display:flex;align-items:center;justify-content:space-between;height:64px;position:relative;gap:20px}
+.site-header .nav{display:flex;align-items:center;justify-content:space-between;height:208px;position:relative;gap:20px}
 .brand{display:flex;align-items:center;gap:10px;font-weight:700}
 .logo{width:28px;height:28px}
 


### PR DESCRIPTION
## Purpose
Based on the conversation context indicating visual changes were requested, this update modifies the site header navigation to provide more vertical space and improve the visual layout.

## Code changes
- Updated `.site-header .nav` height from `64px` to `208px` in `styles.css`
- This change affects the main navigation bar height while maintaining all other styling properties (flex layout, alignment, positioning, etc.)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f79b18a1670547c19903ab9c8db850df/mystic-realm)

👀 [Preview Link](https://f79b18a1670547c19903ab9c8db850df-mystic-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f79b18a1670547c19903ab9c8db850df</projectId>-->
<!--<branchName>mystic-realm</branchName>-->